### PR TITLE
updated the date check

### DIFF
--- a/index.js
+++ b/index.js
@@ -39,8 +39,12 @@ async function checkProjects() {
       })
       .sort((a, b) => a.localeCompare(b))
   )]
+
+  const today = new Date();
+  const fiveYearsAgo = new Date(today.getFullYear() - 5, today.getMonth(), today.getDate());
+
   const startDate = new Date('2000-01-01')
-  const lastDate = new Date('2023-05-01')
+
   for (let i = 0; i < repos.length; i++) {
     if (!repos[i].startsWith('https://github.com')) {
       continue
@@ -56,7 +60,7 @@ async function checkProjects() {
         console.log(data.name, data.created_at)
         if (data.private === false
           && new Date(data.created_at) >= startDate
-          && new Date(data.created_at) <= lastDate
+          && new Date(data.created_at) <= fiveYearsAgo
           && data.archived === false
           && data.disabled === false
           && data.is_template === false


### PR DESCRIPTION
# Fix project creation date filtering logic

## Problem

The current date filtering logic in `checkProjects()` function incorrectly allows projects that are less than 5 years old to be included. The hardcoded `lastDate` of `2023-05-01` means that in 2025, projects created in 2023 (only ~2 years old) are being accepted instead of projects that are truly "at least five years old".

## Root Cause

```javascript
const lastDate = new Date('2023-05-01')
// ...
&& new Date(data.created_at) <= lastDate
```

This hardcoded date doesn't account for the current year, causing the 5-year requirement to be incorrectly applied.

## Solution

Replace the hardcoded date with dynamic calculation based on the current date:

```javascript
// Calculate the date that's exactly 5 years ago from today
const today = new Date()
const fiveYearsAgo = new Date(today.getFullYear() - 5, today.getMonth(), today.getDate())

// Filter condition becomes:
&& new Date(data.created_at) <= fiveYearsAgo
```

## Changes Made

- Removed hardcoded `lastDate = new Date('2023-05-01')`
- Added dynamic `fiveYearsAgo` calculation
- Updated the filtering condition to use the calculated date


## Closes

Fixes #9

---

**Before**: Projects from 2023 were being included in 2025 (only ~2 years old)  
**After**: Only projects from 2020 or earlier are included in 2025 (truly 5+ years old)